### PR TITLE
Updated `yaml.load` to `yaml.safe_load`

### DIFF
--- a/faicon/models.py
+++ b/faicon/models.py
@@ -20,7 +20,7 @@ def get_icon_list():
             check FAICON_YAML_FILE setting.".format(YAML_FILE)
         )
     with open(file, 'r', encoding='utf-8') as stream:
-        data_loaded = yaml.load(stream)
+        data_loaded = yaml.safe_load(stream)
     return data_loaded
 
 


### PR DESCRIPTION
PyYAML's .load method has been deprecated without the use of a loader and detailed into a security vulnerability, many audit workflows and CI tests are failing and this module works without any issues with just `safe_load`, hence the commit. 
This can be read in detail on their wiki https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation